### PR TITLE
Refactor `UiBooster(Options)` emphasizing extensibility

### DIFF
--- a/src/main/java/de/milchreis/uibooster/UiBooster.java
+++ b/src/main/java/de/milchreis/uibooster/UiBooster.java
@@ -1,11 +1,10 @@
 package de.milchreis.uibooster;
 
-import com.bulenkov.darcula.DarculaLaf;
 import de.milchreis.uibooster.components.*;
 import de.milchreis.uibooster.model.*;
+import de.milchreis.uibooster.model.options.*;
 
 import javax.swing.*;
-import javax.swing.plaf.metal.MetalLookAndFeel;
 import java.awt.*;
 import java.io.File;
 import java.util.Arrays;
@@ -25,34 +24,41 @@ public class UiBooster {
     private final UiBoosterOptions options;
 
     public UiBooster() {
-        this(new UiBoosterOptions(UiBoosterOptions.Theme.DARK_THEME));
+        this(new DefaultUiBoosterOptions());
     }
 
     public UiBooster(UiBoosterOptions options) {
-        this.options = options == null ? new UiBoosterOptions() : options;
-
-        if (options.getTheme() != null) {
-            try {
-                if (options.getTheme() == UiBoosterOptions.Theme.DARK_THEME) {
-                    // Little hack to start working on linux
-                    UIManager.getFont("Label.font");
-                    UIManager.setLookAndFeel(new DarculaLaf());
-
-                } else if (options.getTheme() == UiBoosterOptions.Theme.OS_NATIVE) {
-                    UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
-
-                } else if (options.getTheme() == UiBoosterOptions.Theme.SWING) {
-                    UIManager.setLookAndFeel(new MetalLookAndFeel());
-
-                } else if (options.getTheme() == UiBoosterOptions.Theme.DEFAULT) {
-                    UIManager.setLookAndFeel(UIManager.getLookAndFeel());
-                }
-
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
+        this.options = options;
+        try {
+            UIManager.setLookAndFeel(options.getLookAndFeel());
+        }
+        catch (Exception e) {
+            e.printStackTrace();
         }
     }
+
+    public UiBooster(UiBoosterOptions.Theme options) {
+        switch (options) {
+            case DARK_THEME:
+                this.options = new DarkUiBoosterOptions();
+                break;
+            case SWING:
+                this.options = new SwingUiBoosterOptions();
+                break;
+            case OS_NATIVE:
+                this.options = new OSNativeUiBoosterOptions();
+                break;
+            default:
+                this.options = new DefaultUiBoosterOptions();
+                break;
+        }
+        try {
+            UIManager.setLookAndFeel(this.options.getLookAndFeel());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
 
     /**
      * Shows an info dialog and blocks until the ok button was clicked.

--- a/src/main/java/de/milchreis/uibooster/components/WaitingDialog.java
+++ b/src/main/java/de/milchreis/uibooster/components/WaitingDialog.java
@@ -6,7 +6,6 @@ import javax.swing.*;
 import javax.swing.border.EmptyBorder;
 import java.awt.*;
 
-import static de.milchreis.uibooster.model.UiBoosterOptions.Theme.DARK_THEME;
 
 public class WaitingDialog {
 
@@ -48,8 +47,7 @@ public class WaitingDialog {
 
     public static WaitingDialog showDialog(String message, String title, String largeMessage, UiBoosterOptions options, boolean decorated) {
 
-        String loadingImage = options.getTheme() == DARK_THEME ?
-                "/loading-75_darcular.gif" : "/loading-75.gif";
+        String loadingImage = options.getLoadingImage();
 
         JLabel loading = new JLabel(new ImageIcon(WaitingDialog.class.getResource(loadingImage)));
 

--- a/src/main/java/de/milchreis/uibooster/model/UiBoosterOptions.java
+++ b/src/main/java/de/milchreis/uibooster/model/UiBoosterOptions.java
@@ -1,35 +1,35 @@
 package de.milchreis.uibooster.model;
 
-public class UiBoosterOptions {
+import javax.swing.plaf.basic.BasicLookAndFeel;
 
-    public enum Theme {
-        DARK_THEME, SWING, OS_NATIVE, DEFAULT;
-    }
+/**
+ * Abstract base class for user defined look and feel of the application.
+ *
+ */
+public abstract class UiBoosterOptions {
+  public enum Theme {
+    DARK_THEME, SWING, OS_NATIVE, DEFAULT;
+  }
 
-    private Theme theme = Theme.DARK_THEME;
-    private String iconPath = "/uibooster-default-icon.png";
+  protected final BasicLookAndFeel lookAndFeel;
+  protected final String iconPath;
+  protected final String loadingImage;
 
-    public UiBoosterOptions() {
-    }
+  public UiBoosterOptions(BasicLookAndFeel lookAndFeel, String iconPath, String loadingImage) {
+    this.lookAndFeel = lookAndFeel;
+    this.iconPath = iconPath;
+    this.loadingImage = loadingImage;
+  }
 
-    public UiBoosterOptions(String iconPath) {
-        this.iconPath = iconPath;
-    }
+  public BasicLookAndFeel getLookAndFeel() {
+    return lookAndFeel;
+  }
 
-    public UiBoosterOptions(Theme theme) {
-        this.theme = theme;
-    }
+  public String getIconPath() {
+    return iconPath;
+  }
 
-    public UiBoosterOptions(Theme theme, String iconPath) {
-        this.theme = theme;
-        this.iconPath = iconPath;
-    }
-
-    public String getIconPath() {
-        return iconPath;
-    }
-
-    public Theme getTheme() {
-        return theme;
-    }
+  public String getLoadingImage() {
+    return loadingImage;
+  }
 }

--- a/src/main/java/de/milchreis/uibooster/model/options/DarkUiBoosterOptions.java
+++ b/src/main/java/de/milchreis/uibooster/model/options/DarkUiBoosterOptions.java
@@ -1,0 +1,10 @@
+package de.milchreis.uibooster.model.options;
+
+import com.bulenkov.darcula.DarculaLaf;
+import de.milchreis.uibooster.model.UiBoosterOptions;
+
+public class DarkUiBoosterOptions extends UiBoosterOptions {
+  public DarkUiBoosterOptions() {
+    super(new DarculaLaf(), "/uibooster-default-icon.png", DefaultUiBoosterOptions.defaultLoadingImage);
+  }
+}

--- a/src/main/java/de/milchreis/uibooster/model/options/DefaultUiBoosterOptions.java
+++ b/src/main/java/de/milchreis/uibooster/model/options/DefaultUiBoosterOptions.java
@@ -1,0 +1,17 @@
+package de.milchreis.uibooster.model.options;
+
+import com.bulenkov.darcula.DarculaLaf;
+import de.milchreis.uibooster.model.UiBoosterOptions;
+
+/**
+ * Should the user call UiBooster() (default constructor)
+ * the DefaultOptions will be used.
+ */
+public class DefaultUiBoosterOptions extends UiBoosterOptions {
+  public static final String defaultIconPath = "/uibooster-default-icon.png";
+  public static final String defaultLoadingImage = "/loading-75.gif";
+
+  public DefaultUiBoosterOptions() {
+    super(new DarculaLaf(), defaultIconPath, defaultLoadingImage);
+  }
+}

--- a/src/main/java/de/milchreis/uibooster/model/options/OSNativeUiBoosterOptions.java
+++ b/src/main/java/de/milchreis/uibooster/model/options/OSNativeUiBoosterOptions.java
@@ -1,0 +1,31 @@
+package de.milchreis.uibooster.model.options;
+
+import javax.swing.*;
+import javax.swing.plaf.basic.BasicLookAndFeel;
+import java.lang.reflect.Constructor;
+import com.bulenkov.darcula.DarculaLaf;
+import de.milchreis.uibooster.model.UiBoosterOptions;
+
+public class OSNativeUiBoosterOptions extends UiBoosterOptions {
+
+  /**
+   * Work around the UIManager to maintain Options heirarchy and not
+   * make a unique case for OS Native options directly in
+   * the UiBooster constructor
+   */
+  public static BasicLookAndFeel OSNativeLookAndFeel() {
+    try {
+      String className = UIManager.getSystemLookAndFeelClassName();
+      Class<?> klass = Class.forName(className);
+      Constructor<?> constr = klass.getConstructor();
+      return (BasicLookAndFeel) constr.newInstance();
+    } catch (Exception e) {  // How to handle this case?
+      e.printStackTrace();
+      return new DarculaLaf();
+    }
+  }
+
+  public OSNativeUiBoosterOptions() {
+    super(OSNativeLookAndFeel(), DefaultUiBoosterOptions.defaultIconPath, DefaultUiBoosterOptions.defaultLoadingImage);
+  }
+}

--- a/src/main/java/de/milchreis/uibooster/model/options/SwingUiBoosterOptions.java
+++ b/src/main/java/de/milchreis/uibooster/model/options/SwingUiBoosterOptions.java
@@ -1,0 +1,11 @@
+package de.milchreis.uibooster.model.options;
+
+
+import javax.swing.plaf.metal.MetalLookAndFeel;
+import de.milchreis.uibooster.model.UiBoosterOptions;
+
+public class SwingUiBoosterOptions extends UiBoosterOptions {
+  public SwingUiBoosterOptions() {
+    super(new MetalLookAndFeel(), DefaultUiBoosterOptions.defaultIconPath, DefaultUiBoosterOptions.defaultLoadingImage);
+  }
+}

--- a/src/test/java/de/milchreis/uibooster/ThemeTest.java
+++ b/src/test/java/de/milchreis/uibooster/ThemeTest.java
@@ -16,11 +16,20 @@ class ThemeTest {
             e.printStackTrace();
         }
 
-        UiBooster booster = new UiBooster(new UiBoosterOptions(UiBoosterOptions.Theme.DEFAULT));
-        booster.showInfoDialog("Info message");
+        UiBooster booster = new UiBooster();
+        booster.showInfoDialog("Info Message Empty Constructor");
 
-        UiBooster boosterDark = new UiBooster(new UiBoosterOptions(UiBoosterOptions.Theme.DARK_THEME));
-        boosterDark.showInfoDialog("Info message");
+        UiBooster boosterDefault = new UiBooster(UiBoosterOptions.Theme.DEFAULT);
+        boosterDefault.showInfoDialog("Info message Theme.DEFAULT");
+
+        UiBooster boosterDark = new UiBooster(UiBoosterOptions.Theme.DARK_THEME);
+        boosterDark.showInfoDialog("Info message Theme.DARK_THEME");
+
+        UiBooster boosterSwing = new UiBooster(UiBoosterOptions.Theme.SWING);
+        boosterSwing.showInfoDialog("Info message Theme.SWING");
+
+        UiBooster boosterOSNative = new UiBooster(UiBoosterOptions.Theme.OS_NATIVE);
+        boosterOSNative.showInfoDialog("Info message Theme.OS_NATIVE");
     }
 
 }


### PR DESCRIPTION
Extensibility provided through subclassing the now abstract
`UiBoosterOption` class and polymorphically using its subclasses.
Attempted to remove hardcoded values and move them into
their logical unit (example default loadingImage or iconImage).

Stayed as close as possible to previous `UiBoosterOptions` API
inorder to stay backwards compatible.
Attention was given to the construction of `UiBooster` through
the `Theme` enum.