### PR TITLE
Fix java.util.Map.get(Object) is null

### DIFF
--- a/src/main/java/de/milchreis/uibooster/model/formelements/SelectionFormElement.java
+++ b/src/main/java/de/milchreis/uibooster/model/formelements/SelectionFormElement.java
@@ -62,7 +62,7 @@ public class SelectionFormElement extends FormElement {
 
     public void setPossibilities(List<String> possibilities) {
         this.possibilities = possibilities;
-        box.removeAllItems();
-        possibilities.forEach(box::addItem);
+        box.setModel(new DefaultComboBoxModel<>(possibilities.toArray(new String[0])));
+        box.setSelectedItem(possibilities.get(0));
     }
 }


### PR DESCRIPTION
We discussed this a bit back, but you fix causes a NPE. Make any changes you see fit.
```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException: Cannot invoke "java.lang.Integer.intValue()" because the return value of "java.util.Map.get(Object)" is null
	at com.codeferm.app.PlayUI.onChange(PlayUI.java:133)
	at de.milchreis.uibooster.model.formelements.SelectionFormElement.lambda$createComponent$0(SelectionFormElement.java:25)
```