### PR TITLE
Bring back support for using a previously set look and feel

### DIFF
--- a/src/main/java/de/milchreis/uibooster/UiBooster.java
+++ b/src/main/java/de/milchreis/uibooster/UiBooster.java
@@ -1,11 +1,9 @@
 package de.milchreis.uibooster;
 
+import com.formdev.flatlaf.FlatLightLaf;
 import de.milchreis.uibooster.components.*;
 import de.milchreis.uibooster.model.*;
-import de.milchreis.uibooster.model.options.DarkUiBoosterOptions;
-import de.milchreis.uibooster.model.options.LightUiBoosterOptions;
-import de.milchreis.uibooster.model.options.OSNativeUiBoosterOptions;
-import de.milchreis.uibooster.model.options.SwingUiBoosterOptions;
+import de.milchreis.uibooster.model.options.*;
 import de.milchreis.uibooster.utils.FontHelper;
 
 import javax.swing.*;
@@ -24,7 +22,6 @@ import static de.milchreis.uibooster.utils.ParameterValidator.nonNull;
  * It provides all implemented dialogs.
  */
 public class UiBooster {
-
     private final UiBoosterOptions options;
 
     public UiBooster() {
@@ -64,14 +61,16 @@ public class UiBooster {
                 this.options = new LightUiBoosterOptions(iconPath);
                 break;
             case DARK_THEME:
-            default:
                 this.options = new DarkUiBoosterOptions(iconPath);
+                break;
+            default:
+            case DEFAULT:
+                this.options = new InferredUiBoosterOptions(iconPath);
                 break;
         }
         try {
             FontHelper.setFontInUIManager(font);
             UIManager.setLookAndFeel(this.options.getLookAndFeel());
-
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/main/java/de/milchreis/uibooster/model/options/InferredUiBoosterOptions.java
+++ b/src/main/java/de/milchreis/uibooster/model/options/InferredUiBoosterOptions.java
@@ -1,0 +1,40 @@
+package de.milchreis.uibooster.model.options;
+
+import com.formdev.flatlaf.FlatDarculaLaf;
+import de.milchreis.uibooster.model.UiBoosterOptions;
+
+import javax.swing.LookAndFeel;
+import javax.swing.UIManager;
+import javax.swing.plaf.basic.BasicLookAndFeel;
+
+/**
+ * Uses/Infers an existing and already set look and feel for UIBooster.
+ */
+public class InferredUiBoosterOptions extends UiBoosterOptions {
+    public static BasicLookAndFeel InferredLookAndFeel() {
+        try {
+            LookAndFeel laf = UIManager.getLookAndFeel();
+            if (laf == null) {
+                System.err.println("UIBooster: No previously set look anf feel found! Using default.");
+                return new FlatDarculaLaf();
+            }
+            if (!(laf instanceof BasicLookAndFeel)) {
+                System.err.println("UIBooster: Look and feel is not an instance of BasicLookAndFeel! Using default.");
+                return new FlatDarculaLaf();
+            }
+            return (BasicLookAndFeel) laf;
+        } catch (Exception e) {
+            e.printStackTrace();
+            System.err.println("An unexpected exception occurred while initialising DefaultUiBoosterOptions! Using default.");
+            return new FlatDarculaLaf();
+        }
+    }
+
+    public InferredUiBoosterOptions() {
+        this(defaultIconPath);
+    }
+
+    public InferredUiBoosterOptions(String iconPath) {
+        super(InferredLookAndFeel(), iconPath, defaultLoadingImage);
+    }
+}


### PR DESCRIPTION
Hello again,
I'm not sure what happened, but a while back I created issue #31 about UIBooster essentially always using its own separate look and feel, which I felt is a huge drawback. 
That got changed but it seems that pull request  #44 completely deleted this new functionality.

So, unless I overlooked something, 
I'm proposing to bring it back in the form of InferredUIBoosterOptions.
I'd even opt to make this the default or at least very clear that this is an option. Since, like I said back then, having a consistent look and feel is very important. I suppose making it the default might be too much because you can't know beforehand what laf the user has and hence can't ensure that UIBooster works properly.

But otherwise, any larger application will want UIBooster to use its likely heavily modified laf, not a different one with default settings.

I'm also going to note that the UIBooster constructors look like kind of a mess to me. why was there a DEFAULT theme if DefaultUIBoosterOptions were removed, then it's missing in the enum switch, and why does the Font constructor use it?
I changed it so that DEFAULT now means InferredUIBoosterOptions and I left it at that.

Let me know what you think.