### PR TITLE
Bump colorpicker to 1.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <dependency>
             <groupId>org.drjekyll</groupId>
             <artifactId>colorpicker</artifactId>
-            <version>1.3</version>
+            <version>1.4.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Hi @Milchreis !

There is a new colorpicker version (but no real changes). Perhaps you want to use it?

Best regards

Daniel