### PR TITLE
Force error, warning and info dialogs to appear in front

### DIFF
--- a/src/main/java/de/milchreis/uibooster/UiBooster.java
+++ b/src/main/java/de/milchreis/uibooster/UiBooster.java
@@ -95,6 +95,7 @@ public class UiBooster {
         JDialog dialog = jp.createDialog(null, infoMessage);
         ((Frame) dialog.getParent()).setIconImage(WindowIconHelper.getIcon(options.getIconPath()).getImage());
         dialog.setIconImage(WindowIconHelper.getIcon(options.getIconPath()).getImage());
+        dialog.setAlwaysOnTop(true);
         dialog.setVisible(true);
     }
 
@@ -118,6 +119,7 @@ public class UiBooster {
         JDialog dialog = jp.createDialog(null, title);
         ((Frame) dialog.getParent()).setIconImage(WindowIconHelper.getIcon(options.getIconPath()).getImage());
         dialog.setIconImage(WindowIconHelper.getIcon(options.getIconPath()).getImage());
+        dialog.setAlwaysOnTop(true);
         dialog.setVisible(true);
     }
 
@@ -141,6 +143,7 @@ public class UiBooster {
         JDialog dialog = jp.createDialog(null, title);
         ((Frame) dialog.getParent()).setIconImage(WindowIconHelper.getIcon(options.getIconPath()).getImage());
         dialog.setIconImage(WindowIconHelper.getIcon(options.getIconPath()).getImage());
+        dialog.setAlwaysOnTop(true);
         dialog.setVisible(true);
     }
 


### PR DESCRIPTION
This PR fixes #121, making error, warning and info "blocking" dialogs appear in front of other windows (such as a form), to allow for easier access to press "Ok" to unblock execution. 

Before (having to click on the form window to bring the error to the front: 
https://github.com/Milchreis/UiBooster/assets/80995156/5d433a7a-8f17-4cae-bbbc-68ba6f15fe05

After (error window appears in front from the beginning):
https://github.com/Milchreis/UiBooster/assets/80995156/c1c1f39e-00c8-4cd2-9b18-102aca371000

