### PR TITLE
Fix GitHub Actions Workflow and Jitpack Building

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,9 @@
+jdk:
+  - openjdk11
+before_install:
+  - sdk install java 11.0.11-open
+  - sdk use java 11.0.11-open
+  - sdk install maven
+  - mvn -v
+install:
+  - mvn clean install -Dmaven.javadoc.skip=true -DskipTests

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>de.milchreis</groupId>
-    <artifactId>UiBooster</artifactId>
+    <artifactId>uibooster</artifactId>
     <version>1.21.0</version>
     <packaging>jar</packaging>
 


### PR DESCRIPTION
This PR fixes both GitHub actions and Jitpack releases.

For the GitHub action workflows, the artifactId must be lowercase (I believe it's an issue with GitHub?) It should now complete builds successfully. 

For Jitpack, because the Maven plugins were updated, they require newer versions of Maven to build. The addition of jitpack.yml installs the latest version of Maven and sets it as the default version for compilation, which allows the Jitpack builds to complete successfully. 